### PR TITLE
Add a script to easily launch the android emulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "react-native-scripts start",
     "eject": "react-native-scripts eject",
     "android": "react-native-scripts android",
+    "android-emulator": "$ANDROID_HOME/emulator/emulator -avd $($ANDROID_HOME/emulator/emulator -list-avds | head -n 1)&",
     "ios": "react-native-scripts ios",
     "test": "node node_modules/jest/bin/jest.js --watch"
   },


### PR DESCRIPTION
A device needs to be started before running `react-native run-android`
so to save having to open up Android Studio and launch an emulator
manually; `npm run android-emulator` can be executed instead.