### PR TITLE
Make GoCard provider work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "dependencies": {
+    "cheerio-without-node-native": "^0.20.2",
     "expo": "^22.0.2",
+    "npm": "^6.1.0",
     "react": "16.0.0-beta.5",
     "react-native": "^0.49.5",
     "react-navigation": "^1.0.0-beta.19",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0",
-    "reduxsauce": "^0.7.0"
+    "reduxsauce": "^0.7.0",
+    "reselect": "^3.0.1"
   },
   "devDependencies": {
     "jest-expo": "^22.0.0",

--- a/providers/go_card/actions/index.js
+++ b/providers/go_card/actions/index.js
@@ -1,8 +1,0 @@
-import { createActions } from 'reduxsauce'
-
-const { Creators, Types } = createActions({
-  fetchComplete: ['balance', 'updatedAt']
-})
-
-export { Types }
-export default Creators

--- a/providers/go_card/reducers.js
+++ b/providers/go_card/reducers.js
@@ -1,8 +1,4 @@
-import React from 'react'
 import { createReducer } from 'reduxsauce'
-
-import GoCard from './component'
-import { Types } from './actions'
 
 const initialState = {
   cardNumber: '',

--- a/src/reducers/provider_manager.js
+++ b/src/reducers/provider_manager.js
@@ -3,8 +3,15 @@ import { createReducer } from 'reduxsauce'
 import { Types } from '../../providers/actions'
 
 const initialState = {
+  cards: [],
   loading: false
 }
+
+const fetchAllComplete = (state = initialState, { cards }) => ({
+  ...state,
+  cards: [...state.cards, ...cards],
+  loading: false
+})
 
 const fetchAllStart = (state = initialState) => ({
   ...state,
@@ -12,7 +19,8 @@ const fetchAllStart = (state = initialState) => ({
 })
 
 const handlers = {
-  [Types.FETCH_ALL_START]: fetchAllStart
+  [Types.FETCH_ALL_START]: fetchAllStart,
+  [Types.FETCH_ALL_COMPLETE]: fetchAllComplete
 }
 
 export default createReducer(initialState, handlers)

--- a/src/selectors/provider_manager.js
+++ b/src/selectors/provider_manager.js
@@ -1,1 +1,12 @@
-export const getLoading = ({ providerManager: { loading } }) => loading
+import { createSelector } from 'reselect'
+
+import { getGoCards } from '../../providers/go_card/selectors'
+
+const getProviderManager = ({ providerManager }) => providerManager
+
+export const getLoading = createSelector(
+  getProviderManager,
+  ({ loading }) => loading
+)
+
+export const getCards = createSelector(getProviderManager, ({ cards }) => cards)


### PR DESCRIPTION
GoCard is the public transport card system used in Southeast Queensland,
Australia. It covers Brisbane, the Sunshine Coast, and the Gold Coast.
This is the first provider in the system. User details can't be changed
or added yet and this is work that still needs to happen.

I've been trying to think about how I can stop loading only once all the
different providers are loaded. Considering that I've currently only got
one provider this isn't much of an issue now. I've also decided that
having loading finish once the first card arrives will create a snappier
experience for users and other cards can pop into the list as they're
loaded. We'll see how this goes and reconsider if needed.

I'm adding this first because it's most useful to me.