### PR TITLE
Clear card list when fetching

### DIFF
--- a/src/reducers/provider_manager.js
+++ b/src/reducers/provider_manager.js
@@ -15,6 +15,7 @@ const fetchAllComplete = (state = initialState, { cards }) => ({
 
 const fetchAllStart = (state = initialState) => ({
   ...state,
+  cards: [],
   loading: true
 })
 


### PR DESCRIPTION
Without clearing the card list it was appending new cards to the list so
it was just adding them each time the user refreshed with the same
cards.