### PR TITLE
Load cards when app starts

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,0 +1,8 @@
+import { createActions } from 'reduxsauce'
+
+const { Creators, Types } = createActions({
+  loadComplete: null
+})
+
+export { Types }
+export default Creators

--- a/src/sagas/app.js
+++ b/src/sagas/app.js
@@ -1,0 +1,11 @@
+import { put, take } from 'redux-saga/effects'
+
+import ProviderActions from '../../providers/actions'
+import { Types as AppTypes } from '../actions/app'
+
+const app = function*() {
+  yield take(AppTypes.LOAD_COMPLETE)
+  yield put(ProviderActions.fetchAllStart())
+}
+
+export default app

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,9 +1,10 @@
-import { fork } from 'redux-saga/effects'
+import { all, fork } from 'redux-saga/effects'
 
+import app from './app'
 import providers from '../../providers/sagas'
 
 const root = function*() {
-  yield fork(providers)
+  yield all([fork(app), fork(providers)])
 }
 
 export default root

--- a/src/screens/home/component.js
+++ b/src/screens/home/component.js
@@ -2,4 +2,19 @@ import React from 'react'
 
 import CardList from '../../components/card_list'
 
-export default () => <CardList />
+class Home extends React.Component {
+  constructor(props) {
+    super(props)
+    this.appLoaded = props.appLoaded
+  }
+
+  componentWillMount() {
+    this.appLoaded()
+  }
+
+  render() {
+    return <CardList />
+  }
+}
+
+export default Home

--- a/src/screens/home/container.js
+++ b/src/screens/home/container.js
@@ -1,9 +1,15 @@
 import { connect } from 'react-redux'
 
+import Actions from '../../actions/app'
 import Component from './component'
 
-const mapStateToProps = ({ hack }) => ({
-  welcome: hack
+const mapDispatchToProps = dispatch => ({
+  appLoaded: () => {
+    dispatch(Actions.loadComplete())
+  }
 })
 
-export default connect(mapStateToProps)(Component)
+export default connect(
+  null,
+  mapDispatchToProps
+)(Component)


### PR DESCRIPTION
Before this change a user needed to refresh the app to pull card
balances in. Now it happens automagically.